### PR TITLE
Serialize fields that are relations to another model correctly

### DIFF
--- a/helsinki_gdpr/models.py
+++ b/helsinki_gdpr/models.py
@@ -105,10 +105,15 @@ class SerializableMixin(models.Model):
                     "children": value,
                 }
         else:
-            # concrete field, let's just add the value
+            # concrete field
+            value = _resolve_value()
+
+            if hasattr(value, "serialize"):
+                return value.serialize()
+
             return {
                 "key": field_name.upper(),
-                "value": _resolve_value(),
+                "value": value,
             }
 
     def serialize(self):

--- a/helsinki_gdpr/models.py
+++ b/helsinki_gdpr/models.py
@@ -75,8 +75,8 @@ class SerializableMixin(models.Model):
 
     objects = SerializableManager()
 
-    def _resolve_field(self, model, field):
-        field_name = field.get("name")
+    def _resolve_field(self, model, field_description):
+        field_name = field_description.get("name")
 
         def _resolve_value(data, field):
             if "accessor" in field:
@@ -107,15 +107,15 @@ class SerializableMixin(models.Model):
             # concrete field, let's just add the value
             return {
                 "key": field_name.upper(),
-                "value": _resolve_value(model, field),
+                "value": _resolve_value(model, field_description),
             }
 
     def serialize(self):
         return {
             "key": self._meta.model_name.upper(),
             "children": [
-                self._resolve_field(self, field)
-                for field in self.serialize_fields
-                if self._resolve_field(self, field) is not None
+                self._resolve_field(self, field_description)
+                for field_description in self.serialize_fields
+                if self._resolve_field(self, field_description) is not None
             ],
         }

--- a/helsinki_gdpr/models.py
+++ b/helsinki_gdpr/models.py
@@ -79,12 +79,13 @@ class SerializableMixin(models.Model):
         field_name = field_description.get("name")
 
         def _resolve_value():
+            value = getattr(model, field_name)
+
             if "accessor" in field_description:
                 # call the accessor with value as an argument
-                return field_description["accessor"](getattr(model, field_name))
-            else:
-                # no accessor, return the value
-                return getattr(model, field_name)
+                value = field_description["accessor"](value)
+
+            return value
 
         related_types = {item.name: type(item) for item in model._meta.related_objects}
         if field_name in related_types.keys():

--- a/helsinki_gdpr/models.py
+++ b/helsinki_gdpr/models.py
@@ -78,13 +78,13 @@ class SerializableMixin(models.Model):
     def _resolve_field(self, model, field_description):
         field_name = field_description.get("name")
 
-        def _resolve_value(data, field):
-            if "accessor" in field:
+        def _resolve_value():
+            if "accessor" in field_description:
                 # call the accessor with value as an argument
-                return field["accessor"](getattr(data, field_name))
+                return field_description["accessor"](getattr(model, field_name))
             else:
                 # no accessor, return the value
-                return getattr(data, field_name)
+                return getattr(model, field_name)
 
         related_types = {item.name: type(item) for item in model._meta.related_objects}
         if field_name in related_types.keys():
@@ -107,7 +107,7 @@ class SerializableMixin(models.Model):
             # concrete field, let's just add the value
             return {
                 "key": field_name.upper(),
-                "value": _resolve_value(model, field_description),
+                "value": _resolve_value(),
             }
 
     def serialize(self):

--- a/helsinki_gdpr/models.py
+++ b/helsinki_gdpr/models.py
@@ -113,9 +113,13 @@ class SerializableMixin(models.Model):
     def serialize(self):
         return {
             "key": self._meta.model_name.upper(),
-            "children": [
-                self._resolve_field(self, field_description)
-                for field_description in self.serialize_fields
-                if self._resolve_field(self, field_description) is not None
-            ],
+            "children": list(
+                filter(
+                    lambda x: x is not None,
+                    [
+                        self._resolve_field(self, field_description)
+                        for field_description in self.serialize_fields
+                    ],
+                )
+            ),
         }

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -8,8 +8,8 @@ User = get_user_model()
 
 class UserFactory(factory.django.DjangoModelFactory):
     uuid = factory.Faker("uuid4", cast_to=None)
-    first_name = factory.Faker("first_name")
-    last_name = factory.Faker("last_name")
+    first_name = "First name"
+    last_name = "Last name"
     email = factory.Faker("email")
 
     class Meta:

--- a/tests/models.py
+++ b/tests/models.py
@@ -7,8 +7,11 @@ from helusers.models import AbstractUser
 from helsinki_gdpr.models import SerializableMixin
 
 
-class User(AbstractUser):
-    pass
+class User(AbstractUser, SerializableMixin):
+    serialize_fields = (
+        {"name": "first_name"},
+        {"name": "last_name"},
+    )
 
 
 class Profile(SerializableMixin):
@@ -18,7 +21,8 @@ class Profile(SerializableMixin):
 
     serialize_fields = (
         {"name": "memo"},
-        {"name": "user", "accessor": lambda x: x.first_name},
+        {"name": "user"},
+        {"name": "user", "accessor": lambda x: f"{x.first_name} {x.last_name}"},
         {"name": "extra_data"},
     )
 

--- a/tests/snapshots/snap_test_gdpr_api_query.py
+++ b/tests/snapshots/snap_test_gdpr_api_query.py
@@ -9,7 +9,14 @@ snapshots = Snapshot()
 snapshots["test_get_profile_information_from_gdpr_api 1"] = {
     "children": [
         {"key": "MEMO", "value": "Memo"},
-        {"key": "USER", "value": "First name"},
+        {
+            "children": [
+                {"key": "FIRST_NAME", "value": "First name"},
+                {"key": "LAST_NAME", "value": "Last name"},
+            ],
+            "key": "USER",
+        },
+        {"key": "USER", "value": "First name Last name"},
         {"children": [], "key": "EXTRA_DATA"},
     ],
     "key": "PROFILE",

--- a/tests/snapshots/snap_test_gdpr_api_query.py
+++ b/tests/snapshots/snap_test_gdpr_api_query.py
@@ -9,7 +9,7 @@ snapshots = Snapshot()
 snapshots["test_get_profile_information_from_gdpr_api 1"] = {
     "children": [
         {"key": "MEMO", "value": "Memo"},
-        {"key": "USER", "value": "First"},
+        {"key": "USER", "value": "First name"},
         {"children": [], "key": "EXTRA_DATA"},
     ],
     "key": "PROFILE",

--- a/tests/snapshots/snap_test_models.py
+++ b/tests/snapshots/snap_test_models.py
@@ -9,7 +9,14 @@ snapshots = Snapshot()
 snapshots["test_model_serialization 1"] = {
     "children": [
         {"key": "MEMO", "value": "Memo"},
-        {"key": "USER", "value": "First name"},
+        {
+            "children": [
+                {"key": "FIRST_NAME", "value": "First name"},
+                {"key": "LAST_NAME", "value": "Last name"},
+            ],
+            "key": "USER",
+        },
+        {"key": "USER", "value": "First name Last name"},
         {
             "children": [
                 {"children": [{"key": "DATA", "value": "Extra"}], "key": "EXTRADATA"}

--- a/tests/snapshots/snap_test_models.py
+++ b/tests/snapshots/snap_test_models.py
@@ -9,7 +9,7 @@ snapshots = Snapshot()
 snapshots["test_model_serialization 1"] = {
     "children": [
         {"key": "MEMO", "value": "Memo"},
-        {"key": "USER", "value": "First"},
+        {"key": "USER", "value": "First name"},
         {
             "children": [
                 {"children": [{"key": "DATA", "value": "Extra"}], "key": "EXTRADATA"}

--- a/tests/test_gdpr_api_query.py
+++ b/tests/test_gdpr_api_query.py
@@ -10,8 +10,6 @@ User = get_user_model()
 def test_get_profile_information_from_gdpr_api(
     api_client, profile, snapshot, requests_mock, settings
 ):
-    profile.user.first_name = "First"
-    profile.user.save()
     auth_header = get_api_token_for_user_with_scopes(
         profile.user, [settings.GDPR_API_QUERY_SCOPE], requests_mock
     )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,8 +2,6 @@ from tests.factories import ExtraDataFactory
 
 
 def test_model_serialization(profile, snapshot):
-    profile.user.first_name = "First"
-    profile.user.save()
     ExtraDataFactory(profile=profile)
 
     serialized_profile = profile.serialize()


### PR DESCRIPTION
While making the library more configurable, I encountered an issue that the serialization didn't work for fields that are relations to another model. The `Profile` model's `user` field, as a one-to-one relation to the `User` model, is an example of such a field. The `user` field was previously serialized only with an "accessor" that extracted only a single field from the `User` model. Without an accessor serialization of the `user` field didn't work.

Before fixing the above mentioned issue, I did some refactoring on the serialization code.