### PR TITLE
Fix Coverage generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,13 @@ jobs:
             ${{ runner.os }}-
       - name: Install dependencies
         run: |
-          pip install -r requirements-dev.txt codecov
+          pip install -r requirements-dev.txt pytest-cov
           pip install -e .
       - name: Run tests
         run: pytest -ra -vv --doctest-modules --cov=.
 
-      - name: Coverage
-        run: codecov
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
 
   build:
     name: Build package


### PR DESCRIPTION
The `codecov` Python package [1] has been deprecated and now it has been removed from PyPI too. It can't be used any more. Switch to the current way of uploading coverage data.

[Here's a failed run](https://github.com/City-of-Helsinki/helsinki-profile-gdpr-api/actions/runs/4679462221/jobs/8289767208) from another branch that has the deprecated `codecov` package.

[1] https://github.com/codecov/codecov-python