### PR TITLE
Add more configurability to the library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- `GDPR_API_URL_PATTERN` setting for configuring the GDPR API URL pattern.
 - `GDPR_API_MODEL_LOOKUP` setting for configuring how the GDPR model instance is found.
 - `GDPR_API_USER_PROVIDER` setting for configuring how to obtain a `User` instance from the GDPR model instance.
 - `GDPR_API_DELETER` setting for configuring how data deletion is performed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `GDPR_API_MODEL_LOOKUP` setting for configuring how the GDPR model instance is found.
 - `GDPR_API_USER_PROVIDER` setting for configuring how to obtain a `User` instance from the GDPR model instance.
+- `GDPR_API_DELETER` setting for configuring how data deletion is performed.
 
 ### Changed
 
@@ -15,7 +16,8 @@
 
 - Support for Python 3.6
 - `helsinki_gdpr.views.DeletionNotAllowed` exception class. Raising that exception produced responses with
-  contents that are against the GDPR API specification.
+  contents that are against the GDPR API specification. A user specified function configured with the
+  `GDPR_API_DELETER` setting should be used instead.
 
 ## 0.1.0 - 2021-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- `GDPR_API_MODEL_LOOKUP` setting for configuring how the GDPR model instance is found.
+
 ### Changed
 
 - Respond with a `204 No Content` status code when no data is found for the requested profile.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 ### Removed
 
 - Support for Python 3.6
+- `helsinki_gdpr.views.DeletionNotAllowed` exception class. Raising that exception produced responses with
+  contents that are against the GDPR API specification.
 
 ## 0.1.0 - 2021-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `GDPR_API_MODEL_LOOKUP` setting for configuring how the GDPR model instance is found.
+- `GDPR_API_USER_PROVIDER` setting for configuring how to obtain a `User` instance from the GDPR model instance.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ obj = model.objects.get(pk=id)
 If `pk` is not the correct field lookup to use, set the setting `GDPR_API_MODEL_LOOKUP` to the correct
 value, for example `user__uuid`.
 
+If changing the field lookup that way doesn't solve the model instance searching, it's also possible to
+set the `GDPR_API_MODEL_LOOKUP` setting to an import path to a function, for example
+`myapp.gdpr.get_model_instance`. The function gets called whenever the GDPR API is accessed and the model
+instance is needed. The function gets two arguments, the model class specified by the `GDPR_API_MODEL`
+setting and the id from the GDPR API request's path. The function must return an instance of the model
+specified by the `GDPR_API_MODEL` setting, if an instance is found. If no instance is found, then the
+function must either return `None` or raise a `DoesNotExist` exception of the model.
+
 ## Development
 
 It's good to use a Python virtual environment:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ doesn't work, it's possible to configure a function that will provide the `User`
 achieved by setting the import path of the function to the `GDPR_API_USER_PROVIDER` setting, for example
 `myapp.gdpr.get_user`. The function gets the GDPR API model instance as an argument.
 
+### Controlling how data deletion is performed
+
+By default the GDPR delete operation deletes the `GDPR_API_MODEL` instance and the related `User`
+instance. If that procedure isn't sufficient for the project, it's possible to override the data deletion
+operation. This is achieved by setting the `GDPR_API_DELETER` setting to an import path to a function, for
+example `myapp.gdpr.delete_data`. The function gets two arguments, the `GDPR_API_MODEL` instance and a
+boolean value indicating if this is a dry run or not.
+
+The function gets called within a database transaction, which gets automatically rolled back if it's a dry
+run operation. Thus the function is free to do database modifications even in the dry run case. All
+changes get rolled back afterwards. If it's not a dry run case, then the transaction is committed and all
+changes to the database are persisted.
+
+If the data deletion isn't allowed, the function must raise a `django.db.DatabaseError` exception.
+
 ## Development
 
 It's good to use a Python virtual environment:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,11 @@ run operation. Thus the function is free to do database modifications even in th
 changes get rolled back afterwards. If it's not a dry run case, then the transaction is committed and all
 changes to the database are persisted.
 
-If the data deletion isn't allowed, the function must raise a `django.db.DatabaseError` exception.
+If the data deletion isn't allowed, the function has two ways to indicate this:
+
+- Return a `helsinki_gdpr.types.ErrorResponse` instance. This allows also communicating the reasons
+  why the deletion isn't allowed.
+- Raise a `django.db.DatabaseError` exception.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ backend.
 The configuration above is the minimum needed. With those the app uses the default behaviour.
 The app can also be configured in various ways if the default behaviour is not appropriate.
 
+### Setting the URL pattern
+
+If GDPR API URLs are setup as explained in the Usage section above, the GDPR URL pattern is
+`gdpr-api/v1/profiles/<uuid:pk>`. The first part (`gdpr-api/`) can be set freely in the URL config. The
+rest (`v1/profiles/<uuid:pk>`) can be controlled with the `GDPR_API_URL_PATTERN` setting. It can be set to
+for example `users/<uuid:user_id>/gdpr`. There needs to be **exactly one** named parameter in the URL
+pattern. Its type needs to be `uuid`, name can be chosen freely.
+
 ### Searching the model instance
 
 By default the `GDPR_API_MODEL` is searched with its primary key, something like this:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ setting and the id from the GDPR API request's path. The function must return an
 specified by the `GDPR_API_MODEL` setting, if an instance is found. If no instance is found, then the
 function must either return `None` or raise a `DoesNotExist` exception of the model.
 
+### Obtaining a User model instance
+
+It's required that a `User` model instance can be obtained from the GDPR API model instance specified by
+the `GDPR_API_MODEL` setting. By default the GDPR API model instance's `user` attribute is tried. If that
+doesn't work, it's possible to configure a function that will provide the `User` instance. This is
+achieved by setting the import path of the function to the `GDPR_API_USER_PROVIDER` setting, for example
+`myapp.gdpr.get_user`. The function gets the GDPR API model instance as an argument.
+
 ## Development
 
 It's good to use a Python virtual environment:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,27 @@ backend.
     ]
     ```
 
+## Configurability
+
+The configuration above is the minimum needed. With those the app uses the default behaviour.
+The app can also be configured in various ways if the default behaviour is not appropriate.
+
+### Searching the model instance
+
+By default the `GDPR_API_MODEL` is searched with its primary key, something like this:
+
+```python
+from django.apps import apps
+from django.conf import settings
+
+model = apps.get_model(settings.GDPR_API_MODEL)
+# The `id` is extracted from the request's URL
+obj = model.objects.get(pk=id)
+```
+
+If `pk` is not the correct field lookup to use, set the setting `GDPR_API_MODEL_LOOKUP` to the correct
+value, for example `user__uuid`.
+
 ## Development
 
 It's good to use a Python virtual environment:

--- a/helsinki_gdpr/types.py
+++ b/helsinki_gdpr/types.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import List, Mapping
+
+LocalizedMessage = Mapping[str, str]
+"""Human readable error messages localized to various languages: the keys specify languages and
+the values are the localized messages. The language codes are not well specified. It’s suggested
+that services provide any messages in Finnish (`fi`), Swedish (`sv`) and English (`en`)."""
+
+
+@dataclass
+class Error:
+    """Describes a single error."""
+
+    code: str
+    """A service specific error code for debugging purposes. There is no specification for allowed values."""
+    message: LocalizedMessage
+
+
+@dataclass
+class ErrorResponse:
+    """Response contents for providing a set of errors."""
+
+    errors: List[Error]

--- a/helsinki_gdpr/urls.py
+++ b/helsinki_gdpr/urls.py
@@ -1,8 +1,13 @@
+from django.conf import settings
 from django.urls import path
 
 from helsinki_gdpr.views import GDPRAPIView
 
 app_name = "helsinki_gdpr"
 urlpatterns = [
-    path("v1/profiles/<uuid:pk>", GDPRAPIView.as_view(), name="gdpr_v1"),
+    path(
+        getattr(settings, "GDPR_API_URL_PATTERN", "v1/profiles/<uuid:pk>"),
+        GDPRAPIView.as_view(),
+        name="gdpr_v1",
+    ),
 ]

--- a/helsinki_gdpr/views.py
+++ b/helsinki_gdpr/views.py
@@ -52,9 +52,11 @@ class GDPRAPIView(APIView):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.model = apps.get_model(settings.GDPR_API_MODEL)
+        self.model_lookup = getattr(settings, "GDPR_API_MODEL_LOOKUP", "pk")
 
     def get_object(self) -> SerializableMixin:
-        obj = self.model.objects.get(pk=self.kwargs["pk"])
+        field_lookups = {self.model_lookup: self.kwargs["pk"]}
+        obj = self.model.objects.get(**field_lookups)
         self.check_object_permissions(self.request, obj)
         return obj
 

--- a/helsinki_gdpr/views.py
+++ b/helsinki_gdpr/views.py
@@ -4,19 +4,12 @@ from django.db import DatabaseError, transaction
 from django.utils.module_loading import import_string
 from helusers.oidc import ApiTokenAuthentication
 from rest_framework import serializers, status
-from rest_framework.exceptions import APIException
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from helsinki_gdpr.models import SerializableMixin
-
-
-class DeletionNotAllowed(APIException):
-    status_code = 403
-    default_detail = "Profile cannot be deleted."
-    default_code = "deletion_not_allowed"
 
 
 class DryRunException(Exception):
@@ -130,6 +123,6 @@ class GDPRAPIView(APIView):
             # Deletion is possible. Due to dry run, transaction is rolled back.
             pass
         except DatabaseError:
-            raise DeletionNotAllowed()
+            return Response(status=status.HTTP_403_FORBIDDEN)
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,13 @@
 import datetime
+import sys
 import uuid
+from importlib import reload
 
 import pytest
+from django.conf import settings
+from django.core.signals import setting_changed
+from django.dispatch import receiver
+from django.urls import clear_url_caches
 from helusers.settings import api_token_auth_settings
 from jose import jwt
 from rest_framework.test import APIClient
@@ -93,3 +99,15 @@ def model_lookup_that_throws_exception(model, instance_id):
 
 def get_user_from_extra_data(extra_data):
     return extra_data.profile.user
+
+
+@receiver(setting_changed)
+def _reload_url_conf(setting, **kwargs):
+    if setting == "GDPR_API_URL_PATTERN":
+        clear_url_caches()
+
+        if "helsinki_gdpr.urls" in sys.modules:
+            reload(sys.modules["helsinki_gdpr.urls"])
+
+        if settings.ROOT_URLCONF in sys.modules:
+            reload(sys.modules[settings.ROOT_URLCONF])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,3 +89,7 @@ def model_lookup_that_returns_none(model, instance_id):
 
 def model_lookup_that_throws_exception(model, instance_id):
     return model.objects.get(user__uuid=instance_id)
+
+
+def get_user_from_extra_data(extra_data):
+    return extra_data.profile.user

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,3 +81,11 @@ def get_api_token_for_user_with_scopes(user, scopes: list, requests_mock):
     auth_header = f"{api_token_auth_settings.AUTH_SCHEME} {encoded_jwt}"
 
     return auth_header
+
+
+def model_lookup_that_returns_none(model, instance_id):
+    return model.objects.filter(user__uuid=instance_id).first()
+
+
+def model_lookup_that_throws_exception(model, instance_id):
+    return model.objects.get(user__uuid=instance_id)

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,7 +1,7 @@
 import uuid
 
 from django.conf import settings
-from django.db import models
+from django.db import DatabaseError, models
 from helusers.models import AbstractUser
 
 from helsinki_gdpr.models import SerializableMixin
@@ -25,6 +25,11 @@ class Profile(SerializableMixin):
         {"name": "user", "accessor": lambda x: f"{x.first_name} {x.last_name}"},
         {"name": "extra_data"},
     )
+
+    def delete(self, **kwargs):
+        if self.memo == "nodelete":
+            raise DatabaseError()
+        return super().delete(**kwargs)
 
 
 class ExtraData(SerializableMixin):

--- a/tests/snapshots/snap_test_gdpr_api_delete.py
+++ b/tests/snapshots/snap_test_gdpr_api_delete.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+snapshots = Snapshot()
+
+snapshots["test_deleter_function_can_provide_errors 1"] = {
+    "errors": [
+        {
+            "code": "NO_GO",
+            "message": {"en": "Can't do", "fi": "Ei pysty", "sv": "Kan inte"},
+        }
+    ]
+}

--- a/tests/snapshots/snap_test_gdpr_api_query.py
+++ b/tests/snapshots/snap_test_gdpr_api_query.py
@@ -37,3 +37,39 @@ snapshots["test_model_lookup_can_be_configured_to_a_field 1"] = {
     ],
     "key": "PROFILE",
 }
+
+snapshots[
+    "test_model_lookup_can_be_configured_to_a_function[model_lookup_that_returns_none-True] 1"
+] = {
+    "children": [
+        {"key": "MEMO", "value": "Memo"},
+        {
+            "children": [
+                {"key": "FIRST_NAME", "value": "First name"},
+                {"key": "LAST_NAME", "value": "Last name"},
+            ],
+            "key": "USER",
+        },
+        {"key": "USER", "value": "First name Last name"},
+        {"children": [], "key": "EXTRA_DATA"},
+    ],
+    "key": "PROFILE",
+}
+
+snapshots[
+    "test_model_lookup_can_be_configured_to_a_function[model_lookup_that_throws_exception-True] 1"
+] = {
+    "children": [
+        {"key": "MEMO", "value": "Memo"},
+        {
+            "children": [
+                {"key": "FIRST_NAME", "value": "First name"},
+                {"key": "LAST_NAME", "value": "Last name"},
+            ],
+            "key": "USER",
+        },
+        {"key": "USER", "value": "First name Last name"},
+        {"children": [], "key": "EXTRA_DATA"},
+    ],
+    "key": "PROFILE",
+}

--- a/tests/snapshots/snap_test_gdpr_api_query.py
+++ b/tests/snapshots/snap_test_gdpr_api_query.py
@@ -21,3 +21,19 @@ snapshots["test_get_profile_information_from_gdpr_api 1"] = {
     ],
     "key": "PROFILE",
 }
+
+snapshots["test_model_lookup_can_be_configured_to_a_field 1"] = {
+    "children": [
+        {"key": "MEMO", "value": "Memo"},
+        {
+            "children": [
+                {"key": "FIRST_NAME", "value": "First name"},
+                {"key": "LAST_NAME", "value": "Last name"},
+            ],
+            "key": "USER",
+        },
+        {"key": "USER", "value": "First name Last name"},
+        {"children": [], "key": "EXTRA_DATA"},
+    ],
+    "key": "PROFILE",
+}

--- a/tests/snapshots/snap_test_gdpr_api_query.py
+++ b/tests/snapshots/snap_test_gdpr_api_query.py
@@ -6,6 +6,22 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots["test_gdpr_url_pattern_can_be_configured 1"] = {
+    "children": [
+        {"key": "MEMO", "value": "Memo"},
+        {
+            "children": [
+                {"key": "FIRST_NAME", "value": "First name"},
+                {"key": "LAST_NAME", "value": "Last name"},
+            ],
+            "key": "USER",
+        },
+        {"key": "USER", "value": "First name Last name"},
+        {"children": [], "key": "EXTRA_DATA"},
+    ],
+    "key": "PROFILE",
+}
+
 snapshots["test_get_profile_information_from_gdpr_api 1"] = {
     "children": [
         {"key": "MEMO", "value": "Memo"},

--- a/tests/snapshots/snap_test_gdpr_api_query.py
+++ b/tests/snapshots/snap_test_gdpr_api_query.py
@@ -73,3 +73,8 @@ snapshots[
     ],
     "key": "PROFILE",
 }
+
+snapshots["test_user_provider_function_can_be_configured 1"] = {
+    "children": [{"key": "DATA", "value": "Extra"}],
+    "key": "EXTRADATA",
+}

--- a/tests/test_gdpr_api_delete.py
+++ b/tests/test_gdpr_api_delete.py
@@ -110,3 +110,13 @@ def test_if_profile_not_found_return_204(user, uuid_value):
     response = do_delete(user, uuid_value)
 
     assert response.status_code == 204
+
+
+def test_model_lookup_can_be_configured_to_a_field(profile, settings):
+    settings.GDPR_API_MODEL_LOOKUP = "user__uuid"
+
+    response = do_delete(profile.user, profile.user.uuid)
+
+    assert response.status_code == 204
+    assert Profile.objects.count() == 0
+    assert User.objects.count() == 0

--- a/tests/test_gdpr_api_delete.py
+++ b/tests/test_gdpr_api_delete.py
@@ -85,6 +85,17 @@ def test_delete_profile_dry_run_data_false(false_value, profile):
     assert User.objects.count() == 0
 
 
+def test_deletion_forbidden(profile):
+    profile.memo = "nodelete"
+    profile.save()
+
+    response = do_delete(profile.user, profile.id)
+
+    assert response.status_code == 403
+    assert Profile.objects.count() == 1
+    assert User.objects.count() == 1
+
+
 def test_gdpr_api_requires_authentication(api_client, profile):
     response = api_client.delete(
         reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": profile.id})

--- a/tests/test_gdpr_api_delete.py
+++ b/tests/test_gdpr_api_delete.py
@@ -175,3 +175,19 @@ def test_user_provider_function_can_be_configured(profile, settings):
     assert response.status_code == 204
     assert Profile.objects.count() == 0
     assert User.objects.count() == 0
+
+
+def anonymising_deleter(profile, is_dry_run):
+    profile.memo = "anonymised"
+    profile.save()
+
+
+def test_deleter_function_can_be_configured(profile, settings):
+    settings.GDPR_API_DELETER = "tests.test_gdpr_api_delete.anonymising_deleter"
+
+    response = do_delete(profile.user, profile.id)
+
+    assert response.status_code == 204
+    profile = Profile.objects.get()
+    assert profile.memo == "anonymised"
+    assert User.objects.count() == 1

--- a/tests/test_gdpr_api_delete.py
+++ b/tests/test_gdpr_api_delete.py
@@ -1,5 +1,10 @@
+import urllib
+
+import requests_mock
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+from rest_framework.test import APIClient
 
 from tests.conftest import get_api_token_for_user_with_scopes
 
@@ -8,48 +13,61 @@ from .models import Profile
 User = get_user_model()
 
 
-def test_delete_profile_dry_run_data(
-    true_value, api_client, profile, requests_mock, settings
+def do_delete(
+    user,
+    id_value,
+    scopes=(settings.GDPR_API_DELETE_SCOPE,),
+    query_params=None,
+    data=None,
 ):
-    auth_header = get_api_token_for_user_with_scopes(
-        profile.user, [settings.GDPR_API_DELETE_SCOPE], requests_mock
-    )
-    api_client.credentials(HTTP_AUTHORIZATION=auth_header)
-    response = api_client.delete(
-        reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": profile.id}),
-        data={"dry_run": true_value},
-        format="json",
-    )
+    api_client = APIClient()
+
+    with requests_mock.Mocker() as req_mock:
+        auth_header = get_api_token_for_user_with_scopes(user, scopes, req_mock)
+        api_client.credentials(HTTP_AUTHORIZATION=auth_header)
+
+        if query_params:
+            query = "?" + urllib.parse.urlencode(query_params)
+        else:
+            query = ""
+
+        request_kwargs = {"format": "json"}
+        if data:
+            request_kwargs["data"] = data
+
+        return api_client.delete(
+            reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": id_value}) + query,
+            **request_kwargs,
+        )
+
+
+def test_delete_profile_dry_run_data(true_value, profile):
+    response = do_delete(profile.user, profile.id, data={"dry_run": true_value})
 
     assert response.status_code == 204
     assert Profile.objects.count() == 1
     assert User.objects.count() == 1
 
 
-def test_delete_profile_dry_run_query_params(
-    true_value, api_client, profile, requests_mock, settings
-):
-    auth_header = get_api_token_for_user_with_scopes(
-        profile.user, [settings.GDPR_API_DELETE_SCOPE], requests_mock
-    )
-    api_client.credentials(HTTP_AUTHORIZATION=auth_header)
-    response = api_client.delete(
-        reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": profile.id})
-        + f"?dry_run={true_value}",
-    )
+def test_delete_profile_dry_run_query_params(true_value, profile):
+    response = do_delete(profile.user, profile.id, query_params={"dry_run": true_value})
 
     assert response.status_code == 204
     assert Profile.objects.count() == 1
     assert User.objects.count() == 1
 
 
-def test_delete_profile(api_client, profile, requests_mock, settings):
-    auth_header = get_api_token_for_user_with_scopes(
-        profile.user, [settings.GDPR_API_DELETE_SCOPE], requests_mock
-    )
-    api_client.credentials(HTTP_AUTHORIZATION=auth_header)
-    response = api_client.delete(
-        reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": profile.id})
+def test_delete_profile(profile):
+    response = do_delete(profile.user, profile.id)
+
+    assert response.status_code == 204
+    assert Profile.objects.count() == 0
+    assert User.objects.count() == 0
+
+
+def test_delete_profile_dry_run_query_params_false(false_value, profile):
+    response = do_delete(
+        profile.user, profile.id, query_params={"dry_run": false_value}
     )
 
     assert response.status_code == 204
@@ -57,35 +75,8 @@ def test_delete_profile(api_client, profile, requests_mock, settings):
     assert User.objects.count() == 0
 
 
-def test_delete_profile_dry_run_query_params_false(
-    false_value, api_client, profile, requests_mock, settings
-):
-    auth_header = get_api_token_for_user_with_scopes(
-        profile.user, [settings.GDPR_API_DELETE_SCOPE], requests_mock
-    )
-    api_client.credentials(HTTP_AUTHORIZATION=auth_header)
-    response = api_client.delete(
-        reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": profile.id})
-        + f"?dry_run={false_value}",
-    )
-
-    assert response.status_code == 204
-    assert Profile.objects.count() == 0
-    assert User.objects.count() == 0
-
-
-def test_delete_profile_dry_run_data_false(
-    false_value, api_client, profile, requests_mock, settings
-):
-    auth_header = get_api_token_for_user_with_scopes(
-        profile.user, [settings.GDPR_API_DELETE_SCOPE], requests_mock
-    )
-    api_client.credentials(HTTP_AUTHORIZATION=auth_header)
-    response = api_client.delete(
-        reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": profile.id}),
-        data={"dry_run": false_value},
-        format="json",
-    )
+def test_delete_profile_dry_run_data_false(false_value, profile):
+    response = do_delete(profile.user, profile.id, data={"dry_run": false_value})
 
     assert response.status_code == 204
     assert Profile.objects.count() == 0
@@ -99,32 +90,15 @@ def test_gdpr_api_requires_authentication(api_client, profile):
     assert response.status_code == 401
 
 
-def test_user_can_only_access_his_own_profile(
-    api_client, user, profile, requests_mock, settings
-):
-    auth_header = get_api_token_for_user_with_scopes(
-        user,
-        [settings.GDPR_API_QUERY_SCOPE, settings.GDPR_API_DELETE_SCOPE],
-        requests_mock,
-    )
-    api_client.credentials(HTTP_AUTHORIZATION=auth_header)
+def test_user_can_only_access_his_own_profile(user, profile):
+    response = do_delete(user, profile.id)
 
-    response = api_client.delete(
-        reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": profile.id})
-    )
     assert response.status_code == 403
 
 
-def test_gdpr_delete_requires_correct_delete_scope(
-    api_client, profile, requests_mock, settings
-):
-    auth_header = get_api_token_for_user_with_scopes(
-        profile.user, [settings.GDPR_API_QUERY_SCOPE], requests_mock
-    )
-    api_client.credentials(HTTP_AUTHORIZATION=auth_header)
-
-    response = api_client.delete(
-        reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": profile.id})
+def test_gdpr_delete_requires_correct_delete_scope(profile, settings):
+    response = do_delete(
+        profile.user, profile.id, scopes=[settings.GDPR_API_QUERY_SCOPE]
     )
 
     assert response.status_code == 403
@@ -132,18 +106,7 @@ def test_gdpr_delete_requires_correct_delete_scope(
     assert User.objects.count() == 1
 
 
-def test_if_profile_not_found_return_204(
-    api_client, user, uuid_value, requests_mock, settings
-):
-    auth_header = get_api_token_for_user_with_scopes(
-        user, [settings.GDPR_API_DELETE_SCOPE], requests_mock
-    )
-    api_client.credentials(HTTP_AUTHORIZATION=auth_header)
-    response = api_client.delete(
-        reverse(
-            "helsinki_gdpr:gdpr_v1",
-            kwargs={"pk": uuid_value},
-        )
-    )
+def test_if_profile_not_found_return_204(user, uuid_value):
+    response = do_delete(user, uuid_value)
 
     assert response.status_code == 204

--- a/tests/test_gdpr_api_delete.py
+++ b/tests/test_gdpr_api_delete.py
@@ -1,4 +1,3 @@
-import pytest
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
@@ -116,32 +115,21 @@ def test_user_can_only_access_his_own_profile(
     assert response.status_code == 403
 
 
-@pytest.mark.parametrize("use_correct_scope", [True, False])
-def test_gdpr_delete_requires_correct_scope(
-    use_correct_scope, api_client, profile, requests_mock, settings
+def test_gdpr_delete_requires_correct_delete_scope(
+    api_client, profile, requests_mock, settings
 ):
-    if use_correct_scope:
-        auth_header = get_api_token_for_user_with_scopes(
-            profile.user,
-            [settings.GDPR_API_QUERY_SCOPE, settings.GDPR_API_DELETE_SCOPE],
-            requests_mock,
-        )
-    else:
-        auth_header = get_api_token_for_user_with_scopes(
-            profile.user, [settings.GDPR_API_QUERY_SCOPE], requests_mock
-        )
+    auth_header = get_api_token_for_user_with_scopes(
+        profile.user, [settings.GDPR_API_QUERY_SCOPE], requests_mock
+    )
     api_client.credentials(HTTP_AUTHORIZATION=auth_header)
 
     response = api_client.delete(
         reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": profile.id})
     )
 
-    if use_correct_scope:
-        assert response.status_code == 204
-    else:
-        assert response.status_code == 403
-        assert Profile.objects.count() == 1
-        assert User.objects.count() == 1
+    assert response.status_code == 403
+    assert Profile.objects.count() == 1
+    assert User.objects.count() == 1
 
 
 def test_if_profile_not_found_return_204(

--- a/tests/test_gdpr_api_delete.py
+++ b/tests/test_gdpr_api_delete.py
@@ -92,6 +92,7 @@ def test_deletion_forbidden(profile):
     response = do_delete(profile.user, profile.id)
 
     assert response.status_code == 403
+    assert len(response.content) == 0
     assert Profile.objects.count() == 1
     assert User.objects.count() == 1
 

--- a/tests/test_gdpr_api_query.py
+++ b/tests/test_gdpr_api_query.py
@@ -51,3 +51,12 @@ def test_if_profile_not_found_return_204(user, uuid_value):
     response = do_query(user, uuid_value)
 
     assert response.status_code == 204
+
+
+def test_model_lookup_can_be_configured_to_a_field(profile, snapshot, settings):
+    settings.GDPR_API_MODEL_LOOKUP = "user__uuid"
+
+    response = do_query(profile.user, profile.user.uuid)
+
+    assert response.status_code == 200
+    snapshot.assert_match(response.json())

--- a/tests/test_gdpr_api_query.py
+++ b/tests/test_gdpr_api_query.py
@@ -1,21 +1,26 @@
+import requests_mock
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
+from rest_framework.test import APIClient
 
 from tests.conftest import get_api_token_for_user_with_scopes
 
 User = get_user_model()
 
 
-def test_get_profile_information_from_gdpr_api(
-    api_client, profile, snapshot, requests_mock, settings
-):
-    auth_header = get_api_token_for_user_with_scopes(
-        profile.user, [settings.GDPR_API_QUERY_SCOPE], requests_mock
-    )
-    api_client.credentials(HTTP_AUTHORIZATION=auth_header)
-    response = api_client.get(
-        reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": profile.id})
-    )
+def do_query(user, id_value, scopes=(settings.GDPR_API_QUERY_SCOPE,)):
+    api_client = APIClient()
+
+    with requests_mock.Mocker() as req_mock:
+        auth_header = get_api_token_for_user_with_scopes(user, scopes, req_mock)
+        api_client.credentials(HTTP_AUTHORIZATION=auth_header)
+
+        return api_client.get(reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": id_value}))
+
+
+def test_get_profile_information_from_gdpr_api(profile, snapshot):
+    response = do_query(profile.user, profile.id)
 
     assert response.status_code == 200
     snapshot.assert_match(response.json())
@@ -28,49 +33,21 @@ def test_gdpr_api_requires_authentication(api_client, profile):
     assert response.status_code == 401
 
 
-def test_user_can_only_access_his_own_profile(
-    api_client, user, profile, requests_mock, settings
-):
-    auth_header = get_api_token_for_user_with_scopes(
-        user,
-        [settings.GDPR_API_QUERY_SCOPE, settings.GDPR_API_DELETE_SCOPE],
-        requests_mock,
-    )
-    api_client.credentials(HTTP_AUTHORIZATION=auth_header)
+def test_user_can_only_access_his_own_profile(user, profile):
+    response = do_query(user, profile.id)
 
-    response = api_client.get(
-        reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": profile.id})
-    )
     assert response.status_code == 403
 
 
-def test_gdpr_query_requires_correct_query_scope(
-    api_client, profile, requests_mock, settings
-):
-    auth_header = get_api_token_for_user_with_scopes(
-        profile.user, [settings.GDPR_API_DELETE_SCOPE], requests_mock
-    )
-    api_client.credentials(HTTP_AUTHORIZATION=auth_header)
-
-    response = api_client.get(
-        reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": profile.id})
+def test_gdpr_query_requires_correct_query_scope(profile, settings):
+    response = do_query(
+        profile.user, profile.id, scopes=[settings.GDPR_API_DELETE_SCOPE]
     )
 
     assert response.status_code == 403
 
 
-def test_if_profile_not_found_return_204(
-    api_client, user, uuid_value, requests_mock, settings
-):
-    auth_header = get_api_token_for_user_with_scopes(
-        user, [settings.GDPR_API_QUERY_SCOPE], requests_mock
-    )
-    api_client.credentials(HTTP_AUTHORIZATION=auth_header)
-    response = api_client.get(
-        reverse(
-            "helsinki_gdpr:gdpr_v1",
-            kwargs={"pk": uuid_value},
-        )
-    )
+def test_if_profile_not_found_return_204(user, uuid_value):
+    response = do_query(user, uuid_value)
 
     assert response.status_code == 204

--- a/tests/test_gdpr_api_query.py
+++ b/tests/test_gdpr_api_query.py
@@ -6,6 +6,7 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from tests.conftest import get_api_token_for_user_with_scopes
+from tests.factories import ExtraDataFactory
 
 User = get_user_model()
 
@@ -86,3 +87,16 @@ def test_model_lookup_can_be_configured_to_a_function(
         snapshot.assert_match(response.json())
     else:
         assert response.status_code == 204
+
+
+def test_user_provider_function_can_be_configured(profile, snapshot, settings):
+    ExtraDataFactory(profile=profile)
+
+    settings.GDPR_API_MODEL = "tests.ExtraData"
+    settings.GDPR_API_MODEL_LOOKUP = "profile__id"
+    settings.GDPR_API_USER_PROVIDER = "tests.conftest.get_user_from_extra_data"
+
+    response = do_query(profile.user, profile.id)
+
+    assert response.status_code == 200
+    snapshot.assert_match(response.json())

--- a/tests/test_gdpr_api_query.py
+++ b/tests/test_gdpr_api_query.py
@@ -1,4 +1,3 @@
-import pytest
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
@@ -45,30 +44,19 @@ def test_user_can_only_access_his_own_profile(
     assert response.status_code == 403
 
 
-@pytest.mark.parametrize("use_correct_scope", [True, False])
-def test_gdpr_query_requires_correct_scope(
-    use_correct_scope, api_client, profile, requests_mock, settings
+def test_gdpr_query_requires_correct_query_scope(
+    api_client, profile, requests_mock, settings
 ):
-    if use_correct_scope:
-        auth_header = get_api_token_for_user_with_scopes(
-            profile.user,
-            [settings.GDPR_API_QUERY_SCOPE, settings.GDPR_API_DELETE_SCOPE],
-            requests_mock,
-        )
-    else:
-        auth_header = get_api_token_for_user_with_scopes(
-            profile.user, [settings.GDPR_API_DELETE_SCOPE], requests_mock
-        )
+    auth_header = get_api_token_for_user_with_scopes(
+        profile.user, [settings.GDPR_API_DELETE_SCOPE], requests_mock
+    )
     api_client.credentials(HTTP_AUTHORIZATION=auth_header)
 
     response = api_client.get(
         reverse("helsinki_gdpr:gdpr_v1", kwargs={"pk": profile.id})
     )
 
-    if use_correct_scope:
-        assert response.status_code == 200
-    else:
-        assert response.status_code == 403
+    assert response.status_code == 403
 
 
 def test_if_profile_not_found_return_204(


### PR DESCRIPTION
The first version of this library was very opinionated and assumed quite a lot from the project that would use it. It has since come obvious that those assumptions don't hold for many projects. Projects still using this library has had to circumvent the limitations in various ways. This PR offers configurability to the library so that projects wouldn't need to hack it so much.

There's another PR https://github.com/City-of-Helsinki/example-backend-profile/pull/15 using these new features.