### PR TITLE
ci: replace deprecated gh-action-pypi-publish arguments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,5 +24,4 @@ jobs:
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -2,7 +2,7 @@ name: Publish to TestPyPI
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
   build-and-publish:
@@ -15,7 +15,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.9
-
       - name: Install dependencies
         run: pip install -U setuptools wheel build
       - name: Build
@@ -23,7 +22,7 @@ jobs:
       - name: Publish
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
-          skip_existing: true
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+          verbose: true


### PR DESCRIPTION
Also remove redundant `__token__` username.

Refs: RATYK-90